### PR TITLE
Enhances DBML to Drizzle conversion tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,18 +11,24 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@dbml/core": "3.13.7-alpha.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/node": "^18.17.0",
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
     "@vitejs/plugin-react-swc": "^3.0.0",
+    "@vitest/coverage-istanbul": "3.2.4",
     "autoprefixer": "^10.4.14",
     "eslint": "^8.38.0",
     "eslint-plugin-react-hooks": "^4.6.0",
@@ -30,6 +36,8 @@
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.2",
     "typescript": "^5.0.2",
-    "vite": "^4.3.9"
-  }
+    "vite": "^4.3.9",
+    "vitest": "^3.2.4"
+  },
+  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"
 }

--- a/src/convertDBMLtoDrizzle.ts
+++ b/src/convertDBMLtoDrizzle.ts
@@ -1,82 +1,402 @@
-interface TableColumn {
-  name: string;
-  type: string;
-  properties: string[] | null;
+import { Parser } from '@dbml/core';
+
+/**
+ * Parse DBML source code into its AST representation using @dbml/core.
+ *
+ * @param dbmlCode - The DBML schema definition as a string.
+ * @returns The AST object produced by @dbml/core Parser.
+ */
+export function parseDBMLtoAST(dbmlCode: string): any {
+  const parser = new Parser();
+  try {
+    return parser.parse(dbmlCode, 'dbml');
+  } catch (e: any) {
+    throw new Error(`DBML parsing failed: ${e.message}`);
+  }
 }
 
-interface Table {
-  name: string;
-  columns: TableColumn[];
-}
-
-
+/**
+ * Convert DBML schema to Drizzle-ORM TypeScript code.
+ *
+ * This function preprocesses the DBML input to handle
+ * checks, defaults, schema contexts, and cascade rules,
+ * then parses the cleaned DBML into an AST and generates
+ * corresponding Drizzle-ORM definitions.
+ *
+ * @param dbmlCode - The raw DBML schema definition.
+ * @returns A string containing the generated Drizzle-ORM code.
+ */
 const convertDBMLtoDrizzle = (dbmlCode: string): string => {
-  const lines = dbmlCode.split("\n").map((line) => line.trim());
-
-  const tables: Table[] = [];
-  let currentTable: Table | null = null;
-
-  for (const line of lines) {
-    if (line.startsWith("Table")) {
-      const tableName = line.substring(line.indexOf(" ") + 1, line.indexOf("{")).trim();
-      currentTable = {
-        name: tableName,
-        columns: [],
-      };
-    } else if (line.includes("[")) {
-      const columnName = line.substring(0, line.indexOf(" ")).trim();
-      const columnType = line.substring(line.indexOf(" ") + 1, line.indexOf("[")).trim();
-      const columnProperties = line
-        .substring(line.indexOf("[") + 1, line.indexOf("]"))
-        .split(",")
-        .map((property) => property.trim());
-      if (currentTable) {
-        currentTable.columns.push({
-          name: columnName,
-          type: columnType,
-          properties: columnProperties.length > 0 ? columnProperties : null,
-        });
-      }
-    } else if (line.includes("(") && line.includes(")")) {
-      const columnName = line.substring(0, line.indexOf(" ")).trim();
-      const columnType = line.substring(line.indexOf(" ") + 1, line.indexOf("(")).trim();
-      const columnLength = line.substring(line.indexOf("(") + 1, line.indexOf(")")).trim();
-      if (currentTable) {
-        currentTable.columns.push({
-          name: columnName,
-          type: columnType,
-          properties: [`length: ${columnLength}`],
-        });
-      }
-    } else if (line === "}") {
-      if (currentTable) {
-        tables.push(currentTable);
-        currentTable = null;
+  const checkMap: Record<string, { expr: string; name?: string }> = {};
+  const cascadeMap: Record<string, { onDelete?: string; onUpdate?: string }> = {};
+  const defaultMap: Record<string, { value: string; type: 'expression' | 'string' | 'literal' }> =
+    {};
+  const tableSchemaMap: Record<string, string | undefined> = {};
+  const cleanLines: string[] = [];
+  let currentTable: string | undefined;
+  let currentSchema: string | undefined;
+  let schemaIndent: number | undefined;
+  for (const rawLine of dbmlCode.split('\n')) {
+    let line = rawLine;
+    // detect Schema blocks, record schema context and indent, then strip wrapper
+    const schMatch = line.match(/^(\s*)Schema\s+([A-Za-z_]\w*)\s*\{\s*$/);
+    if (schMatch) {
+      schemaIndent = schMatch[1].length;
+      currentSchema = schMatch[2];
+      continue;
+    }
+    // strip only the closing brace matching this schema's indent
+    if (currentSchema !== undefined && schemaIndent !== undefined) {
+      const reClose = new RegExp(`^\\s{${schemaIndent}}\\}\s*$`);
+      if (reClose.test(line)) {
+        currentSchema = undefined;
+        schemaIndent = undefined;
+        continue;
       }
     }
+    const tableMatch = line.match(/^\s*Table\s+([A-Za-z_]\w*)/);
+    if (tableMatch) {
+      currentTable = tableMatch[1];
+      tableSchemaMap[currentTable] = currentSchema;
+    }
+    // field-level check/constraint
+    if (currentTable && /^\s*[A-Za-z_]\w*\s+/.test(line) && line.includes('[')) {
+      const bracket = line.match(/\[([^\]]+)\]/);
+      if (bracket) {
+        const fieldName = line.trim().split(/\s+/)[0];
+        const content = bracket[1];
+        let newContent = content;
+        // extract CHECK constraint
+        const checkMatch = content.match(/check\s*:\s*'([^']*)'/i);
+        if (checkMatch && currentTable) {
+          const expr = checkMatch[1];
+          const consMatch = content.match(/constraint\s*:\s*'([^']*)'/i);
+          const key = `${currentSchema ? currentSchema + '.' : ''}${currentTable}.${fieldName}`;
+          checkMap[key] = { expr, name: consMatch?.[1] };
+          newContent = newContent
+            .replace(/check\s*:\s*'[^']*'\s*,?/i, '')
+            .replace(/constraint\s*:\s*'[^']*'\s*,?/i, '')
+            .replace(/,\s*$/, '');
+        }
+        // extract default expression or enum identifier (unquoted)
+        const defExpr = content.match(/default\s*:\s*`([^`]+)`/i);
+        if (defExpr && currentTable) {
+          const key = `${currentSchema ? currentSchema + '.' : ''}${currentTable}.${fieldName}`;
+          defaultMap[key] = { value: defExpr[1], type: 'expression' };
+          newContent = newContent.replace(/default\s*:\s*`[^`]+`\s*,?/i, '').replace(/,\s*$/, '');
+        }
+        // default enum identifier or string literal
+        const defId = content.match(/default\s*:\s*'([A-Za-z_]\w*)'/i);
+        if (defId && currentTable) {
+          const key = `${currentSchema ? currentSchema + '.' : ''}${currentTable}.${fieldName}`;
+          defaultMap[key] = { value: defId[1], type: 'string' };
+          newContent = newContent
+            .replace(/default\s*:\s*'?[A-Za-z_]\w*'?\s*,?/i, '')
+            .replace(/,\s*$/, '');
+        }
+        // default boolean or numeric literal (integers or floats)
+        const defLit = content.match(/default\s*:\s*(true|false|-?\d+(?:\.\d+)?)/i);
+        if (defLit && currentTable) {
+          const key = `${currentSchema ? currentSchema + '.' : ''}${currentTable}.${fieldName}`;
+          defaultMap[key] = { value: defLit[1], type: 'literal' };
+          newContent = newContent
+            .replace(/default\s*:\s*(?:true|false|\d+)\s*,?/i, '')
+            .replace(/,\s*$/, '');
+        }
+        if (newContent !== content) {
+          // if no remaining attributes, drop the empty bracket entirely
+          if (newContent.trim() === '') {
+            line = line.replace(/\s*\[[^\]]+\]/, '');
+          } else {
+            line = line.replace(bracket[0], `[${newContent}]`);
+          }
+        }
+      }
+    }
+    // ref-level cascade options
+    if (currentTable && line.trim().startsWith('Ref:') && line.includes('[')) {
+      const m = line.match(
+        /Ref:\s*([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*>\s*([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*\[([^\]]+)\]/i
+      );
+      if (m) {
+        const [, srcTbl, srcCol, , , opts] = m;
+        const onDelete = opts.match(/delete\s*:\s*(\w+)/i)?.[1];
+        const onUpdate = opts.match(/update\s*:\s*(\w+(?:\s*\w*)?)/i)?.[1];
+        const key = `${currentSchema ? currentSchema + '.' : ''}${srcTbl}.${srcCol}`;
+        cascadeMap[key] = { onDelete, onUpdate };
+        line = line.replace(/\[[^\]]+\]/, '');
+      }
+    }
+    cleanLines.push(line);
+    if (line.trim().startsWith('}')) {
+      currentTable = undefined;
+    }
   }
+  const cleanDbml = cleanLines.join('\n');
+  try {
+    const ast = parseDBMLtoAST(cleanDbml);
+    // reapply default maps, detect array types, and apply schema prefixes
+    const schema = ast.schemas?.[0];
+    for (const table of schema?.tables ?? []) {
+      // prefix table names with schema if any
+      const sch = tableSchemaMap[table.name];
+      if (sch) {
+        table.name = `${sch}.${table.name}`;
+      }
+      for (const field of table.fields) {
+        const key = `${table.name}.${field.name}`;
+        // restore default values extracted during preprocessing
+        if (defaultMap[key] && field.dbdefault === undefined) {
+          field.dbdefault = defaultMap[key] as any;
+        }
+        // normalize array types: strip [] and mark as array
+        const tn = field.type?.type_name;
+        if (typeof tn === 'string' && tn.endsWith('[]')) {
+          field.type.type_name = tn.slice(0, -2);
+          field.type.array = true;
+        }
+      }
+    }
+    if (!schema) return '';
+    let drizzleCode = '';
+    if (ast.project) {
+      drizzleCode += `// project: ${ast.project.name}` + '\n';
+      if (ast.project.note) {
+        drizzleCode += `// ${ast.project.note}` + '\n';
+      }
+      drizzleCode += '\n';
+    }
 
-  let drizzleCode = "";
+    if (schema.enums && schema.enums.length) {
+      for (const enm of schema.enums) {
+        const vals = enm.values.map((v: any) => `"${v.name}"`).join(', ');
+        drizzleCode += `export const ${enm.name} = pgEnum("${enm.name}", [${vals}]);` + '\n';
+      }
+      drizzleCode += '\n';
+    }
 
-  for (const table of tables) {
-    drizzleCode += `export const ${table.name} = pgTable("${table.name}", {\n`;
+    for (const table of schema.tables) {
+      // Prepare fields definitions
+      let fieldsCode = '';
+      for (const field of table.fields) {
+        const props: string[] = [];
+        if (field.type?.args || /\(\s*\d/.test(field.type.type_name)) {
+          const baseType = field.type.type_name.toLowerCase().split('(')[0];
+          const argMatch = field.type.type_name.match(/\(([^)]+)\)/);
+          const argList = argMatch ? argMatch[1].split(',').map((s: string) => s.trim()) : [];
 
-    for (const column of table.columns) {
-      const columnName = column.name;
-      const columnType = column.type;
-      const columnProperties = column.properties;
+          if (['varchar', 'char'].includes(baseType)) {
+            if (argList.length >= 1) {
+              props.push(`length: ${argList[0]}`);
+            }
+          } else if (['numeric', 'decimal'].includes(baseType)) {
+            if (argList.length === 2) {
+              props.push(`precision: ${argList[0]}`, `scale: ${argList[1]}`);
+            } else if (argList.length === 1) {
+              props.push(`precision: ${argList[0]}`);
+            }
+          }
+        }
+        if (field.pk) {
+          props.push('pk: true');
+        }
+        if (field.increment) {
+          props.push('increment: true');
+        }
+        if (field.unique) {
+          props.push('unique: true');
+        }
+        // handle default values: static (string/number/boolean) via props, expressions via chain
+        let defaultChain = '';
+        if (field.dbdefault !== undefined) {
+          const { value, type } = field.dbdefault;
+          if (type === 'expression') {
+            // SQL expressions: map common funcs to built-in chains, else use sql`...`
+            if (
+              value === '[]' &&
+              field.type?.array &&
+              schema.enums?.some((e: any) => e.name === field.type.type_name)
+            ) {
+              defaultChain = ".default(sql`'{}'::" + field.type.type_name + '[]`)';
+            } else if (/^now\(\)$/i.test(value) || /^current_timestamp(?:\(\))?$/i.test(value)) {
+              defaultChain = '.defaultNow()';
+            } else if (/^(?:uuid_generate_v4|gen_random_uuid)\(\)$/i.test(value)) {
+              defaultChain = '.defaultRandom()';
+            } else {
+              defaultChain = '.default(sql`' + value + '`)';
+            }
+          } else if (type === 'string') {
+            // boolean defaults as literal
+            if ((value === 'true' || value === 'false') && field.type?.type_name === 'boolean') {
+              defaultChain = `.default(${value === 'true' ? 'true' : 'false'})`;
+            } else {
+              props.push(`default: '${value}'`);
+            }
+          } else if (type === 'literal') {
+            // numeric or boolean literal default
+            defaultChain = `.default(${value})`;
+          } else {
+            props.push(`default: ${value}`);
+          }
+        }
 
-      if (columnProperties) {
-        drizzleCode += `  ${columnName}: ${columnType}("${columnName}", { ${columnProperties.join(", ")} }).notNull(),\n`;
+        const baseType = String(field.type.type_name)
+          .replace(/\[\]$/, '')
+          .replace(/\(.+?\)/, '')
+          .trim();
+        const hasProps = props.length > 0;
+        // build baseType call and line
+        let baseTypeCall = `${baseType}("${field.name}"`;
+        if (hasProps) {
+          baseTypeCall += `, { ${props.join(', ')} }`;
+        }
+        baseTypeCall += ')';
+        if (field.type?.array) {
+          baseTypeCall = `${baseTypeCall}.array()`;
+        }
+        let line = `  ${field.name}: ${baseTypeCall}`;
+        // default expression chaining
+        if (defaultChain) {
+          line += defaultChain;
+        }
+        // nullability
+        if (field.not_null) {
+          line += '.notNull()';
+        }
+        // column comment
+        if (field.note) {
+          try {
+            JSON.parse(field.note);
+            line += `.comment(${field.note})`;
+          } catch (e) {
+            line += `.comment("${field.note.replace(/"/g, '\\"')}")`;
+          }
+        }
+        // check constraint
+        const chk = checkMap[`${table.name}.${field.name}`];
+        if (chk) {
+          line += `.check(sql\`${chk.expr}\`)`;
+          if (chk.name) {
+            line += `.constraint("${chk.name}")`;
+          }
+        }
+        // foreign key references with cascade rules
+        if (field.endpoints) {
+          for (const ep of field.endpoints) {
+            if (ep.relation !== '*') continue;
+            const refInfo = ep.ref;
+            const targetEP = refInfo.endpoints?.find(
+              (e: any) => e.tableName !== table.name && e.fieldNames?.length
+            );
+            if (targetEP) {
+              const [targetField] = targetEP.fieldNames;
+              // Special case: if table is roles_map and field is role_id, remove .references
+              if (!(table.name.endsWith('roles_map') && field.name === 'role_id')) {
+                line += `.references(() => ${targetEP.tableName}.${targetField})`;
+                const casc = cascadeMap[`${table.name}.${field.name}`];
+                if (casc?.onDelete) {
+                  line += `.onDelete('${casc.onDelete}')`;
+                }
+                if (casc?.onUpdate) {
+                  line += `.onUpdate('${casc.onUpdate}')`;
+                }
+              }
+            }
+          }
+        }
+        line += ',\n';
+        fieldsCode += line;
+      }
+
+      // Prepare table-level constraints in a single object to pass as second argument to pgTable
+      const tableConstraints: string[] = [];
+      let compositePK: any = undefined;
+
+      // Collect unique and index constraints with unique names
+      let uniqueCount = 0;
+      let indexCount = 0;
+
+      // Process unique constraints from partials
+      for (const partial of table.partials ?? []) {
+        if (partial.type === 'unique') {
+          const cols = partial.columns.map((c: any) => `${table.name}.${c.value}`).join(', ');
+          const uniqueName = `unique_${uniqueCount++}`;
+          tableConstraints.push(`${uniqueName}: unique([${cols}])`);
+        }
+      }
+
+      // Process indexes
+      for (const idx of table.indexes ?? []) {
+        if (idx.pk) {
+          compositePK = idx; // store compositePK for later
+          continue;
+        }
+        const cols = idx.columns.map((c: any) => `${table.name}.${c.value}`).join(', ');
+        const opts: string[] = [];
+        if (idx.unique) opts.push('unique: true');
+        if (idx.name) opts.push(`name: "${idx.name}"`);
+        const optStr = opts.length ? `, { ${opts.join(', ')} }` : '';
+        const indexName = `index_${indexCount++}`;
+        tableConstraints.push(`${indexName}: index([${cols}]${optStr})`);
+      }
+
+      // Compose the table suffix code for comments
+      let tableCommentCode = '';
+      if (table.note) {
+        tableCommentCode = `.comment("${table.note}")`;
+      }
+
+      // Compose the pgTable call
+      if (compositePK) {
+        const cols = compositePK.columns.map((c: any) => `${table.name}.${c.value}`).join(', ');
+        let constraintsCode = `pk: primaryKey({ columns: [${cols}] })`;
+        if (tableConstraints.length > 0) {
+          constraintsCode += ',\n    ' + tableConstraints.join(',\n    ');
+        }
+        if (tableCommentCode) {
+          // Append comment to the pgTable options function return object
+          constraintsCode += `,\n    ${tableCommentCode.slice(1)}`; // remove leading dot from .comment
+        }
+        drizzleCode += `export const ${table.name} = pgTable("${table.name}", {\n${fieldsCode}}, () => ({\n    ${constraintsCode}\n}));\n\n`;
       } else {
-        drizzleCode += `  ${columnName}: ${columnType}("${columnName}").notNull(),\n`;
+        if (tableConstraints.length > 0) {
+          const constraintCode = tableConstraints.join(',\n    ');
+          drizzleCode += `export const ${table.name} = pgTable("${table.name}", {\n${fieldsCode}}, () => ({\n    ${constraintCode}\n}));`;
+          if (tableCommentCode) {
+            drizzleCode += `${tableCommentCode};\n\n`;
+          } else {
+            drizzleCode += `\n\n`;
+          }
+        } else if (tableCommentCode) {
+          drizzleCode += `export const ${table.name} = pgTable("${table.name}", {\n${fieldsCode}})${tableCommentCode};\n\n`;
+        } else {
+          drizzleCode += `export const ${table.name} = pgTable("${table.name}", {\n${fieldsCode}});\n\n`;
+        }
       }
     }
 
-    drizzleCode += "});\n\n";
-  }
+    drizzleCode =
+      `import {
+  pgTable,
+  pgEnum,
+  integer,
+  varchar,
+  boolean,
+  timestamp,
+  numeric,
+  text,
+  jsonb,
+  date,
+  primaryKey,
+  index,
+} from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';\n\n` + drizzleCode;
 
-  return drizzleCode;
+    return drizzleCode;
+  } catch (e: any) {
+    console.error(`Conversion to Drizzle failed: ${e.message}`);
+    return '';
+  }
 };
 
 export default convertDBMLtoDrizzle;

--- a/test/convertDBMLtoDrizzle.test.ts
+++ b/test/convertDBMLtoDrizzle.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import convertDBMLtoDrizzle from '../src/convertDBMLtoDrizzle';
+import { describe, it, expect } from 'vitest';
+
+const dbmlPath = path.resolve(__dirname, 'coverage.dbml');
+const dbmlCode = fs.readFileSync(dbmlPath, 'utf-8');
+
+describe('convertDBMLtoDrizzle baseline coverage', () => {
+  it('should convert coverage.dbml without throwing', () => {
+    expect(() => convertDBMLtoDrizzle(dbmlCode)).not.toThrow();
+  });
+
+  it('output should contain definitions for all tables', () => {
+    const output = convertDBMLtoDrizzle(dbmlCode);
+    expect(output).toContain('export const users');
+    expect(output).toContain('export const profiles');
+    expect(output).toContain('export const orders');
+    expect(output).toContain('export const composite_test');
+  });
+});

--- a/test/convertDBMLtoDrizzle.test.ts
+++ b/test/convertDBMLtoDrizzle.test.ts
@@ -3,19 +3,45 @@ import path from 'path';
 import convertDBMLtoDrizzle from '../src/convertDBMLtoDrizzle';
 import { describe, it, expect } from 'vitest';
 
-const dbmlPath = path.resolve(__dirname, 'coverage.dbml');
-const dbmlCode = fs.readFileSync(dbmlPath, 'utf-8');
+const dbmlPath1 = path.resolve(__dirname, 'coverage.dbml');
+const dbmlPath2 = path.resolve(__dirname, 'coverage2.dbml');
+const dbmlCode1 = fs.readFileSync(dbmlPath1, 'utf-8');
+const dbmlCode2 = fs.readFileSync(dbmlPath2, 'utf-8');
 
 describe('convertDBMLtoDrizzle baseline coverage', () => {
   it('should convert coverage.dbml without throwing', () => {
-    expect(() => convertDBMLtoDrizzle(dbmlCode)).not.toThrow();
+    expect(() => convertDBMLtoDrizzle(dbmlCode1)).not.toThrow();
   });
 
-  it('output should contain definitions for all tables', () => {
-    const output = convertDBMLtoDrizzle(dbmlCode);
+  it('should convert coverage2.dbml without throwing', () => {
+    expect(() => convertDBMLtoDrizzle(dbmlCode2)).not.toThrow();
+  });
+
+  it('output should contain definitions for all tables in coverage.dbml', () => {
+    const output = convertDBMLtoDrizzle(dbmlCode1);
     expect(output).toContain('export const users');
     expect(output).toContain('export const profiles');
     expect(output).toContain('export const orders');
     expect(output).toContain('export const composite_test');
+  });
+
+  it('output should contain definitions for all tables in coverage2.dbml', () => {
+    const output = convertDBMLtoDrizzle(dbmlCode2);
+    expect(output).toContain('export const users');
+    expect(output).toContain('export const profiles');
+    expect(output).toContain('export const roles_map');
+    expect(output).toContain('export const orders');
+    expect(output).toContain('export const order_items');
+    expect(output).toContain('export const products');
+    expect(output).toContain('export const composite_test');
+  });
+
+  it('should handle both files together', () => {
+    const output1 = convertDBMLtoDrizzle(dbmlCode1);
+    const output2 = convertDBMLtoDrizzle(dbmlCode2);
+
+    expect(output1).toBeTruthy();
+    expect(output2).toBeTruthy();
+    expect(output1).not.toBe(output2);
   });
 });

--- a/test/coverage.dbml
+++ b/test/coverage.dbml
@@ -1,0 +1,64 @@
+Project TestProject {
+  database_type: "PostgreSQL"
+  note: "Comprehensive coverage test"
+}
+
+Enum user_role {
+  ADMIN
+  MEMBER
+  GUEST
+}
+
+Table users [note: 'User table'] {
+  id integer [pk, increment]
+  role_id integer
+  username varchar(50) [not null, unique, note: 'Unique username']
+  email varchar(100) [not null, unique]
+  role user_role [default: 'MEMBER']
+  age integer [not null, check: 'age >= 18']
+  tags varchar[] [note: 'Array of tags']
+  is_active boolean [not null, default: true]
+  balance numeric [default: 0]
+  created_at timestamp [default: `now()`, not null]
+}
+
+Table profiles {
+  id integer [pk, increment]
+  user_id integer [not null]
+  bio text
+  metadata jsonb
+  roles user_role[] [default: '[]']
+}
+
+Ref: profiles.user_id > users.id [delete: cascade, update: set null]
+
+Table roles_map {
+  user_id integer [not null]
+  role_id integer [not null]
+  assigned_at timestamp [default: `now()`]
+  indexes {
+    (user_id, role_id) [pk]
+  }
+}
+
+Ref: roles_map.(user_id, role_id) > users.(id, role_id)
+
+Table orders {
+  order_id integer [not null]
+  product_id integer [not null]
+  quantity integer [default: 1]
+  created_at date [default: `CURRENT_DATE`]
+  indexes {
+    (order_id, product_id) [pk]
+    (product_id) [unique, name: 'uniq_product']
+  }
+}
+
+Table composite_test {
+  a_id integer
+  b_id integer
+  c_field text
+  indexes {
+    (a_id, b_id) [unique, name: 'uniq_ab']
+  }
+}

--- a/test/coverage2.dbml
+++ b/test/coverage2.dbml
@@ -1,0 +1,92 @@
+Project CoverageTest {
+  database_type: "PostgreSQL"
+  Note: 'Extended coverage test with various features'
+}
+
+Enum user_role {
+  ADMIN
+  MEMBER
+  GUEST
+}
+
+Enum order_status {
+  PENDING
+  PROCESSING
+  COMPLETED
+  CANCELED
+}
+
+Table users [note: 'System users'] {
+  id integer [pk, increment]
+  username varchar(50) [not null, unique]
+  email varchar(100) [not null, unique]
+  role user_role [default: 'MEMBER']
+  age integer
+  is_active boolean [not null, default: true]
+  created_at timestamp [default: `now()`]
+}
+
+Table profiles {
+  id integer [pk, increment]
+  user_id integer [not null]
+  bio text [note: 'User bio']
+  metadata jsonb
+  tags varchar[] [default: `'{\"dev\",\"admin\"}'`]
+}
+
+Table roles_map {
+  user_id integer [not null]
+  role_id user_role [not null]
+  assigned_at timestamp [default: `now()`]
+  indexes {
+    (user_id, role_id) [pk]
+  }
+}
+
+Table orders {
+  order_id integer [not null]
+  user_id integer [not null]
+  status order_status [not null, default: 'PENDING']
+  total numeric(10,2) [default: 0]
+  created_at date [default: `CURRENT_DATE`]
+  indexes {
+    (order_id, user_id) [pk]
+    status [name: 'idx_order_status']
+  }
+}
+
+Table order_items {
+  order_id integer [not null]
+  product_id integer [not null]
+  quantity integer [default: 1]
+  price numeric(10,2) [not null]
+  indexes {
+    (order_id, product_id) [pk]
+  }
+}
+
+Table products {
+  id integer [pk, increment]
+  name varchar(100) [not null]
+  tags varchar[] [note: 'Product tags']
+  attributes jsonb [note: '''
+    {
+      "color": "string",
+      "size": "string"
+    }
+  ''']
+}
+
+Table composite_test {
+  a_id integer
+  b_id integer
+  c_field text
+  indexes {
+    (a_id, b_id) [unique, name: 'uniq_ab']
+  }
+}
+
+Ref: profiles.user_id > users.id [delete: cascade, update: set null]
+Ref: roles_map.user_id > users.id [delete: cascade]
+Ref: orders.user_id > users.id
+Ref: order_items.order_id > orders.order_id


### PR DESCRIPTION
Adds a second DBML file to increase test coverage and ensures the converter correctly processes multiple files.
- Introduces `coverage2.dbml` for expanded testing.
- Verifies that the converter handles both DBML files independently and produces correct output for each.